### PR TITLE
Allowed for empty list results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ config
 .dist/*
 hpna.egg-info
 hpna.egg-info/*
+.vscode

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 =======
 
+1.0.7
+-----
+- Fix: Allow for results that are missing to return an empty result instead of raise an error.
+       For instance, if a diagnostic is searched and is missing, it will now return an None or empty list.
+- Fix: Allow for query results that return a HTTP 201 status code to succeed.
+
 1.0.6
 -----
 
@@ -22,8 +28,6 @@ History
 
 1.0.5
 -----
-
-Released: 2019-02-19
 
 - Fix: HTTP status code 501 causing exception.
 - Fix: HTTP status code 204 causing exception.

--- a/hpnapy/__init__.py
+++ b/hpnapy/__init__.py
@@ -17,7 +17,7 @@ Basic usage:
 """
 
 __title__ = 'HPNA Python Library'
-__version__ = '1.0.6'
+__version__ = '1.0.7'
 __author__ = 'Spencer Ervin'
 __license__ = 'GNU General Public License v3.0'
 

--- a/hpnapy/hpnapy.py
+++ b/hpnapy/hpnapy.py
@@ -1113,7 +1113,7 @@ class _NAConnector:
             if api_result.ResultSet.Row:
                 return api_result.ResultSet.Row
         except AttributeError:
-            self._raise_hpna_fault_exception()
+            pass
         return []
 
     def _get_extracted_single_result(self, api_result):
@@ -1124,7 +1124,7 @@ class _NAConnector:
             try:
                 return api_result.Text
             except AttributeError:
-                self._raise_hpna_fault_exception()
+                pass None
         return None
 
     def _get_api_query_response(self, command_to_call, **kwargs):

--- a/hpnapy/hpnapy.py
+++ b/hpnapy/hpnapy.py
@@ -1124,7 +1124,7 @@ class _NAConnector:
             try:
                 return api_result.Text
             except AttributeError:
-                pass None
+                pass
         return None
 
     def _get_api_query_response(self, command_to_call, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import sys
 if sys.version_info < (3, 4):
     sys.exit('hpnapy requires Python 3.4+')
 
-VERSION = '1.0.6'
+VERSION = '1.0.7'
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
Allow for empty results to return properly. This is caused when an item is missing from the result set, such as a diagnostic does not exist.